### PR TITLE
CIS-3351 Fix Incorrect Property Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgrade to messaging-lib 0.2.0 for email subject prefix support. (CIS-3351)
-- Use the value of `octri.messaging.default-sender-address` property if `octri.authentication.account-message-email` is not set.
+- Use the value of `octri.messaging.email.default-sender-address` property if `octri.authentication.account-message-email` is not set.
 - Publish -SNAPSHOT releases to Maven Central. (CIS-3368)
+
+### Fixed
+
+- Fix incorrect messaging-lib property name in default sender address fallback logic. (CIS-3351)
 
 ## [3.0.0] - 2025-09-29
 

--- a/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationConfiguration.java
+++ b/authentication_lib/src/main/java/org/octri/authentication/config/OctriAuthenticationConfiguration.java
@@ -37,7 +37,7 @@ public class OctriAuthenticationConfiguration {
 			"octri.authentication.saml.enabled"
 	};
 
-	private static final String FALLBACK_EMAIL_PROPERTY = "octri.messaging.default-sender-address";
+	private static final String FALLBACK_EMAIL_PROPERTY = "octri.messaging.email.default-sender-address";
 
 	private final String contextPath;
 	private final OctriAuthenticationProperties authenticationProperties;


### PR DESCRIPTION
# Overview

Correct property name in email address fallback logic. Fixes a crash triggered by using `octri.messaging.email.default-sender-address` to configure the address used to send account management messages.

## Issues

[CIS-3351](https://jirabp.ohsu.edu/browse/CIS-3351)

[X] Added to CHANGELOG.md
